### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CMD C:\temp> powershell.exe -ExecutionPolicy Bypass -File .\jaws-enum.ps1
 ```
 **Run from within PS Shell and write out to file.**
 ```
-PS C:\temp> .\jaws-enum.ps1 -OutputFileName Jaws-Enum.txt
+PS C:\temp> .\jaws-enum.ps1 | Out-File Jaws-Enum.txt
 ```
 
 ## Current Features


### PR DESCRIPTION
 -OutputFileName kept giving me perm issues on some test machines. using .\Jaws-enum.ps1 | Out-File outtest.txt Seemed to work alot more of the time.