### PR TITLE
Fixed path for HKCU check in AlwaysInstallElevated

### DIFF
--- a/jaws-enum.ps1
+++ b/jaws-enum.ps1
@@ -223,7 +223,7 @@ function JAWS-ENUM {
     }
     if (($HKCU | test-path) -eq "True") 
     {
-        if (((Get-ItemProperty -Path $HKLM -Name AlwaysInstallElevated).AlwaysInstallElevated) -eq 1)
+        if (((Get-ItemProperty -Path $HKCU -Name AlwaysInstallElevated).AlwaysInstallElevated) -eq 1)
         {
             $output = $output +   "AlwaysInstallElevated enabled on this host!"
         }


### PR DESCRIPTION
Noticed that the AlwaysInstallElevated checks for HKLM and HKCU had the same command for the actual value check of the registry key. Looked like it could be a typo.